### PR TITLE
Added a global timeout context

### DIFF
--- a/src/getfile_test.go
+++ b/src/getfile_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+	"context"
 )
 
 /**
@@ -35,7 +36,7 @@ func TestGetFile(t *testing.T) {
 
 		t.Log("Length: ", l)
 
-		if pr, err := gf.Pieces(COUNT, SIZE); err != nil {
+		if pr, err := gf.Pieces(context.Background(), COUNT, SIZE); err != nil {
 			t.Error("failed to get file pieces: ", err.Error())
 		} else if bs, err := ioutil.ReadAll(pr); err != nil {
 			t.Error("Failed to read bytes: ", err.Error())


### PR DESCRIPTION
This patch adds a global context.Context option, which is passed into the method which does file retrieval.  This is an initial timeout control (30 seconds) which can be leveraged to offer more complex canceling functionality.

Related to issue #12 